### PR TITLE
Add animated gradient background

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <style>
       html,
       body {
-        font-family: 'Poppins', sans-serif;
+        font-family: "Poppins", sans-serif;
       }
       html {
         background: linear-gradient(135deg, #fff5eb, #ffe4e1);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -116,11 +116,9 @@ export default function Chat() {
   };
 
   return (
-    <div
-      className="h-[100vh] w-full p-4 flex justify-center items-center bg-fixed overflow-hidden bg-gradient-to-br from-orange-50 via-rose-100 to-purple-200 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800"
-    >
+    <div className="h-[100vh] w-full p-4 flex justify-center items-center bg-fixed overflow-hidden animated-gradient">
       <HasOpenAIKey />
-        <div className="h-[calc(100vh-2rem)] w-full mx-auto max-w-lg flex flex-col shadow-xl rounded-md overflow-hidden relative border border-neutral-300 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur-lg">
+      <div className="h-[calc(100vh-2rem)] w-full mx-auto max-w-lg flex flex-col shadow-xl rounded-md overflow-hidden relative border border-neutral-300 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur-lg">
         <div className="px-4 py-3 border-b border-neutral-300 dark:border-neutral-800 flex items-center gap-3 sticky top-0 z-10">
           <div className="flex items-center justify-center h-8 w-8">
             <svg

--- a/src/styles.css
+++ b/src/styles.css
@@ -310,3 +310,40 @@
     transform: rotate(360deg) scale(0.9);
   }
 }
+
+/* Animated gradient background */
+@keyframes gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.animated-gradient {
+  background-image: linear-gradient(
+    270deg,
+    #ffedd5,
+    #ffe4e6,
+    #e9d5ff,
+    #ffe4e6,
+    #ffedd5
+  );
+  background-size: 400% 400%;
+  animation: gradient-shift 12s ease infinite;
+}
+
+.dark .animated-gradient {
+  background-image: linear-gradient(
+    270deg,
+    #111827,
+    #1f2937,
+    #374151,
+    #1f2937,
+    #111827
+  );
+}


### PR DESCRIPTION
## Summary
- add new `gradient-shift` keyframes for animated gradients
- create `.animated-gradient` class for light and dark themes
- apply the animated gradient class to the main container
- format files with Prettier

## Testing
- `npm run check` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: network unreachable)*